### PR TITLE
feature: Add word, lexeme and meaning IDs to the search results

### DIFF
--- a/lib/dictionary/domain/dictionary-entry.ts
+++ b/lib/dictionary/domain/dictionary-entry.ts
@@ -120,6 +120,7 @@ export type WordForm =
 
 export interface IDictionaryEntry {
 	word: string;
+	wordId: string;
 	wordForms: WordForm;
 	partOfSpeech: partOfSpeechesTag[];
 	meanings: Meaning[];
@@ -131,18 +132,29 @@ export interface IDictionaryEntry {
 
 export class DictionaryEntry implements IDictionaryEntry {
 	word: string;
+	wordId: string;
 	partOfSpeech: partOfSpeechesTag[];
 	meanings: Meaning[];
 	wordForms: WordForm;
 
-	constructor(word: string, partOfSpeech: Array<partOfSpeechesTag>, meanings: Array<Meaning>, wordForms: WordForm) {
+	constructor(
+		word: string,
+		wordId: string,
+		partOfSpeech: Array<partOfSpeechesTag>,
+		meanings: Array<Meaning>,
+		wordForms: WordForm
+	) {
 		this.word = word;
+		this.wordId = wordId;
 		this.partOfSpeech = partOfSpeech;
 		this.wordForms = wordForms;
 		this.meanings = meanings;
 	}
 	getWord(): string {
 		return this.word;
+	}
+	getWordId(): string {
+		return this.wordId;
 	}
 	getPartOfSpeech(): partOfSpeechesTag[] {
 		return this.partOfSpeech;

--- a/lib/dictionary/infrastructure/dictionary-v2/ekilex/dictonary-ekilex.ts
+++ b/lib/dictionary/infrastructure/dictionary-v2/ekilex/dictonary-ekilex.ts
@@ -85,6 +85,8 @@ export default class DictonaryEkilex implements ExternalDictionaryV2 {
 		}, {});
 
 		return {
+			lexemeId: lexeme.lexemeId,
+			meaningId: lexeme.meaningId,
 			definition: definitions,
 			partOfSpeech: partOfSpeechTags,
 			rection,
@@ -102,27 +104,6 @@ export default class DictonaryEkilex implements ExternalDictionaryV2 {
 		}
 
 		return searchResult.words.map((word) => word.wordId);
-		//  TODO fix
-		// Scraping https://sonaveeb.ee/search/unif/est/eki/tubil/1 is broken
-		// const resultHtml = await this.sonaveebClient.getResultPage(searchTerm);
-
-		// const root = parse(resultHtml);
-
-		// const otherForm = root.querySelector('[id=form-words] [data-word]');
-
-		// if (!otherForm?.textContent) {
-		// 	return [];
-		// }
-
-		// const newWord = otherForm.textContent;
-
-		// const newSearchResult = await this.ekilexClient.words.search(newWord, ['eki']);
-
-		// if (newSearchResult.totalCount > 0) {
-		// 	return newSearchResult.words.map((word) => word.wordId);
-		// }
-
-		// return [];
 	}
 
 	async getDictionaryEntry(searchTerm: string): Promise<DictionaryResponseV2> {
@@ -140,7 +121,7 @@ export default class DictonaryEkilex implements ExternalDictionaryV2 {
 
 				const wordForms = wordDetail.word.paradigms.map(this.extractWordFormsFromParadigm).flat();
 
-				const rest = wordDetail.lexemes
+				const meanings = wordDetail.lexemes
 					.filter((lexeme) => lexeme.datasetCode === 'eki')
 					.map(this.extractFromLexeme);
 
@@ -150,9 +131,10 @@ export default class DictonaryEkilex implements ExternalDictionaryV2 {
 						?.members?.map((member) => member.wordValue) ?? [];
 
 				return {
+					wordId: wordDetail.word.wordId,
 					wordClasses,
 					wordForms,
-					meanings: rest,
+					meanings,
 					similarWords,
 				};
 			});

--- a/lib/dictionary/infrastructure/dictionary-v2/inMemory/dictionary-in-memory.ts
+++ b/lib/dictionary/infrastructure/dictionary-v2/inMemory/dictionary-in-memory.ts
@@ -6,6 +6,7 @@ export default class DictionaryV2InMemory implements ExternalDictionaryV2 {
 	async getDictionaryEntry(searchTerm: string): Promise<DictionaryResponseV2> {
 		return [
 			{
+				wordId: '247445',
 				partOfSpeech: ['noomen'],
 				wordForms: [
 					{ inflectionType: '16', code: 'SgN', morphValue: 'ainsuse nimetav', value: 'tubli' },
@@ -45,6 +46,8 @@ export default class DictionaryV2InMemory implements ExternalDictionaryV2 {
 				],
 				meanings: [
 					{
+						lexemeId: '1369121',
+						meaningId: '110954',
 						definition:
 							'(inimese vm elusolendi kohta:) millegagi hästi hakkama saav, ootustele vastav, omadustelt millekski hea ja sobiv,selline, kes saab hästi hakkama, on milleski hea',
 						examples:
@@ -71,6 +74,8 @@ export default class DictionaryV2InMemory implements ExternalDictionaryV2 {
 						],
 					},
 					{
+						lexemeId: '1369122',
+						meaningId: '110955',
 						definition:
 							'(nähtuste, olukordade vms kohta:) selline, mis väärib tunnustust, tulemuslik, kiiduväärt,tunnustust vääriv,hea, korralik',
 						examples: 'Esikoht on tubli tulemus.,Tubli töö, ajakirjanikud!,Tänan kolleege tubli töö eest!',
@@ -92,11 +97,15 @@ export default class DictionaryV2InMemory implements ExternalDictionaryV2 {
 						],
 					},
 					{
+						lexemeId: '1369123',
+						meaningId: '110956',
 						definition: '(esemete kohta:) heas korras, oma ülesannet hästi täitev, vastupidav vms',
 						examples: 'Mehed hankisid ülesõiduks tubli paadi.',
 						synonyms: ['toimiv', 'tegus', 'korralik', 'vastupidav'],
 					},
 					{
+						lexemeId: '1369124',
+						meaningId: '110957',
 						definition: 'märgib üldisemalt millegi suurust, tugevust, intensiivsust, tõhusust',
 						examples: 'Poiss sai isalt tubli keretäie.,Retsensioon sisaldas tubli annuse kriitikat.',
 						synonyms: [
@@ -111,12 +120,6 @@ export default class DictionaryV2InMemory implements ExternalDictionaryV2 {
 							'tüse,priske',
 							'tugev',
 						],
-					},
-					{
-						definition:
-							'(rõhutava sõnana:) kinnitab, et midagi on mainitavast hulgast, määrast pigem rohkem kui vähem',
-						examples: 'Jäime esimestest tubli pool tundi maha.',
-						synonyms: ['kõva'],
 					},
 				],
 			},

--- a/lib/dictionary/infrastructure/dictionary/inMemory/dictionary-in-memory.ts
+++ b/lib/dictionary/infrastructure/dictionary/inMemory/dictionary-in-memory.ts
@@ -5,6 +5,7 @@ import { right } from '@lib/shared/common/either';
 
 export default class DictionaryInMemory implements ExternalDictionary {
 	async getWord(word: string): Promise<DictionaryResponse> {
+		const wordId = '247445';
 		const partOfSpeechesTags: Array<partOfSpeechesTag> = ['omadussõna'];
 		const wordForms = {
 			singular: {
@@ -41,7 +42,7 @@ export default class DictionaryInMemory implements ExternalDictionary {
 			},
 		];
 
-		const dictionaryEntry = new DictionaryEntry(word, partOfSpeechesTags, meanings, wordForms);
+		const dictionaryEntry = new DictionaryEntry(word, wordId, partOfSpeechesTags, meanings, wordForms);
 		return right(dictionaryEntry);
 	}
 }

--- a/lib/dictionary/infrastructure/dictionary/sonaveeb/dictonary-sonaveeb.ts
+++ b/lib/dictionary/infrastructure/dictionary/sonaveeb/dictonary-sonaveeb.ts
@@ -27,7 +27,7 @@ export default class DictonarySonaveeb implements ExternalDictionary {
 			const wordId = await this.getWordId(word);
 
 			if (!wordId) {
-				const dictionaryEntry = new DictionaryEntry(word, [], [], []);
+				const dictionaryEntry = new DictionaryEntry(word, '', [], [], []);
 
 				return right(dictionaryEntry);
 			}
@@ -45,7 +45,7 @@ export default class DictonarySonaveeb implements ExternalDictionary {
 				this.logger
 			)(partOfSpeechesTags[0], rootElement);
 
-			const dictionaryEntry = new DictionaryEntry(word, partOfSpeechesTags, meanings, wordForms);
+			const dictionaryEntry = new DictionaryEntry(word, wordId, partOfSpeechesTags, meanings, wordForms);
 
 			return right(dictionaryEntry);
 		} catch (err) {
@@ -62,6 +62,8 @@ export default class DictonarySonaveeb implements ExternalDictionary {
 	}
 
 	private async getWordId(word: string) {
+		//  TODO fix
+		// Scraping https://sonaveeb.ee/search/unif/est/eki/tubli/1 is broken
 		const resultHtml = await this.sonaveebClient.getResultPage(word);
 		const root = parse(resultHtml);
 


### PR DESCRIPTION
Add word, lexeme and meaning IDs from ekilex to API response

This would help to have a source of unique IDs